### PR TITLE
chore: update import paths for Chroma and OpenAIEmbeddings

### DIFF
--- a/ml/src/main.py
+++ b/ml/src/main.py
@@ -335,7 +335,6 @@ async def not_found_handler(request, exc):
         }
     )
 
-
 # 메인 실행
 if __name__ == "__main__":
     # 환경변수에서 설정 읽기

--- a/ml/src/vectordb/loaders/load_case_db.py
+++ b/ml/src/vectordb/loaders/load_case_db.py
@@ -7,8 +7,10 @@ search_case_chain.py 등 외부에서 import하여 사용합니다.
 
 import os
 from dotenv import load_dotenv
-from langchain.vectorstores import Chroma
-from langchain.embeddings import OpenAIEmbeddings
+# from langchain.vectorstores import Chroma
+# from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import OpenAIEmbeddings
 
 load_dotenv()
 openai_key = os.getenv("OPENAI_API_KEY")

--- a/ml/src/vectordb/loaders/load_law_db.py
+++ b/ml/src/vectordb/loaders/load_law_db.py
@@ -7,8 +7,10 @@ search_law_chain.py 등 외부에서 import하여 사용합니다.
 
 import os
 from dotenv import load_dotenv
-from langchain.vectorstores import Chroma
-from langchain.embeddings import OpenAIEmbeddings
+# from langchain.vectorstores import Chroma
+# from langchain.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import OpenAIEmbeddings
 
 load_dotenv()
 openai_key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
LangChain 최신 버전에 맞춰 Chroma 및 OpenAIEmbeddings의 import 경로를 기존 langchain.* 에서 langchain_community.* 로 수정하였습니다.

이는 구조 변경에 따른 경로 이슈를 방지하고,
호환성을 유지하기 위한 리팩터링입니다.