### PR TITLE
Fix duplicate case_id issue and improve LLM prompt structure

### DIFF
--- a/ml/config.py
+++ b/ml/config.py
@@ -73,6 +73,8 @@ CLAUDE_MODEL = os.getenv("CLAUDE_MODEL")
 CLAUDE_TEMPERATURE = 0.1
 CLAUDE_MAX_TOKENS = 4_000
 
+GPT_MODEL = os.getenv("GPT_MODEL")
+
 # ───────────────────────────────────────────
 # 로깅·성능·검색·보안 등 고정 상수
 # ───────────────────────────────────────────

--- a/ml/src/services/generate_letter_chain.py
+++ b/ml/src/services/generate_letter_chain.py
@@ -41,9 +41,6 @@ letter_prompt = ChatPromptTemplate.from_template(
 관련 법령:
 {related_laws_str}
 
-관련 판례:
-{related_cases_str}
-
 계약 정보:
 {contract_summary}
 

--- a/ml/src/services/schema/analyze_schema.py
+++ b/ml/src/services/schema/analyze_schema.py
@@ -83,7 +83,7 @@ class ContractAnalysisOutput(BaseModel):
 
     # 기본 메타데이터
     id: int = Field(description="분석 결과 고유 ID")
-    user_id: int = Field(description="사용자 ID")
+    user_id: str = Field(description="사용자 ID")
     contract_id: int = Field(description="계약서 ID")
     created_date: str = Field(description="생성 날짜")
 

--- a/ml/src/services/schema/letter_schema.py
+++ b/ml/src/services/schema/letter_schema.py
@@ -38,7 +38,7 @@ class LetterGenerationOutput(BaseModel):
 
     # 4순위: 메타데이터
     id: Optional[int] = None
-    user_id: Optional[int] = None
+    user_id: Optional[str] = None
     contract_id: Optional[int] = None
     created_date: Optional[str] = None
     certification_metadata: CertificationMetadata

--- a/ml/src/services/schema/terms_schema.py
+++ b/ml/src/services/schema/terms_schema.py
@@ -56,7 +56,7 @@ class ContractInput(BaseModel):
 class ContractOutput(BaseModel):
     # 메타데이터
     id: Optional[int] = Field(None, description="응답 고유 ID")
-    user_id: Optional[int] = Field(None, description="사용자 ID")
+    user_id: Optional[str] = Field(None, description="사용자 ID")
     contract_id: Optional[int] = Field(None, description="계약서 ID")
     created_date: datetime = Field(default_factory=datetime.now, description="생성일시")
 

--- a/ml/src/services/shared/llm_config.py
+++ b/ml/src/services/shared/llm_config.py
@@ -5,7 +5,7 @@
 """
 
 # config import 추가
-from config import CLAUDE_MODEL
+from config import CLAUDE_MODEL, GPT_MODEL
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import ChatOpenAI
 
@@ -30,6 +30,14 @@ def get_claude_llm_for_review():
     """계약서 검토용 Claude LLM 설정"""
     return ChatAnthropic(
         model=CLAUDE_MODEL,
+        temperature=0,  # 정확한 분석을 위해 낮은 temperature
+        max_tokens=6000,
+    )
+
+def get_gpt_llm_for_review():
+    """계약서 검토용 gpt LLM 설정"""
+    return ChatOpenAI(
+        model=GPT_MODEL,
         temperature=0,  # 정확한 분석을 위해 낮은 temperature
         max_tokens=6000,
     )


### PR DESCRIPTION
이번 PR에서는 다음과 같은 수정 사항을 반영했습니다:

1. 🔧 `document_search.py` 수정  
   - 중복된 `case_id`가 반환되는 문제를 `set()`으로 해결하였습니다.  
   - 검색 결과의 정확성과 효율성을 높였습니다.

2. ⚙️ `config.py` 및 `llm_config.py` 개선  
   - GPT 모델명을 `config.py`에서 중앙 관리하도록 상수 추가  
   - 계약서 검토 기능용 LLM 설정 함수를 `llm_config.py`에 신설하여 코드 분리 및 재사용성을 높였습니다.

3. 🧹 프롬프트 수정  
   - 계약서 검토용 프롬프트에서 관련 판례 안내 부분 제거  
   - 현재 기능에서는 법령 중심 안내만 필요하다고 판단

4. user_id를 int -> str로 

